### PR TITLE
Remaining /applications endpoints

### DIFF
--- a/app/js/actions/init.js
+++ b/app/js/actions/init.js
@@ -63,6 +63,10 @@ var _actions = keymirror({
     getUser: null,
     listUsers: null,
 
+    // Applications
+    appDetail: null,
+    appList: null,
+
     // Deploy stream
     deployStreamFail: null,
     deployStreamReset: null,

--- a/app/js/beacons/templates/beacon.html
+++ b/app/js/beacons/templates/beacon.html
@@ -16,7 +16,12 @@
       <tbody>
         <tr ng-repeat="instance in instances track by $index">
           <td>
-            <a href="/instances/{{ instance.Alias }}">{{ instance.Alias }}</a>
+            <div ng-if="instance.CanAccessDocker">
+              <a href="/instances/{{ instance.Alias }}">{{ instance.Alias }}</a>
+            </div>
+            <div ng-if="!instance.CanAccessDocker">
+              {{ instance.Alias }}
+            </div>
           </td>
           <td>{{ instance.InstanceAddress }}</td>
           <td>{{ instance.CanAccessDocker }}</td>

--- a/app/js/deploy/appController.js
+++ b/app/js/deploy/appController.js
@@ -43,6 +43,19 @@ function appController($scope, $rootScope, appListModel, deployService) {
             'name': $scope.info.Name
         });
     };
+
+    $scope.update = function () {
+        // Publish recent deployment for the update controller
+        // patching in the Instances list of the top-level app info
+        var apps = appListModel.apps();
+        $scope.recent.Instances = _.findWhere(apps, {'Id': $scope.info.Id}).Instances;
+
+        $rootScope.$broadcast('deploy.update', {
+            'id': $scope.info.Id,
+            'name': $scope.info.Name,
+            'recent': $scope.recent
+        });
+    };
 }
 
 appController.$inject = ['$scope', '$rootScope', 'appListModel', 'deployService'];

--- a/app/js/deploy/appController.js
+++ b/app/js/deploy/appController.js
@@ -25,6 +25,14 @@ function appController($scope, appListModel, deployService) {
         $scope.detail = appListModel.detail($scope.info.Id);
         $scope.recent = _.first($scope.detail);
     });
+
+    $scope.start = function (id) {
+        deployService.start(id, $scope.info.Name);
+    };
+
+    $scope.stop = function (id) {
+        deployService.stop(id, $scope.info.Name);
+    };
 }
 
 appController.$inject = ['$scope', 'appListModel', 'deployService'];

--- a/app/js/deploy/appController.js
+++ b/app/js/deploy/appController.js
@@ -19,6 +19,7 @@ var _ = require('lodash');
 function appController($scope, appListModel, deployService) {
     'use strict';
 
+    $scope.showHistory = false;
     deployService.detail($scope.info.Id);
 
     $scope.$listenTo(appListModel, function () {

--- a/app/js/deploy/appController.js
+++ b/app/js/deploy/appController.js
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2015 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+var _ = require('lodash');
+
+function appController($scope, appListModel, deployService) {
+    'use strict';
+
+    deployService.detail($scope.info.Id);
+
+    $scope.$listenTo(appListModel, function () {
+        $scope.detail = appListModel.detail($scope.info.Id);
+        $scope.recent = _.first($scope.detail);
+    });
+}
+
+appController.$inject = ['$scope', 'appListModel', 'deployService'];
+module.exports = appController;

--- a/app/js/deploy/appController.js
+++ b/app/js/deploy/appController.js
@@ -16,7 +16,7 @@
 
 var _ = require('lodash');
 
-function appController($scope, appListModel, deployService) {
+function appController($scope, $rootScope, appListModel, deployService) {
     'use strict';
 
     $scope.showHistory = false;
@@ -34,7 +34,16 @@ function appController($scope, appListModel, deployService) {
     $scope.stop = function (id) {
         deployService.stop(id, $scope.info.Name);
     };
+
+    $scope.revert = function (target) {
+        // Publish target ID for the revert controller
+        $rootScope.$broadcast('deploy.revert', {
+            'id': $scope.info.Id,
+            'target': target,
+            'name': $scope.info.Name
+        });
+    };
 }
 
-appController.$inject = ['$scope', 'appListModel', 'deployService'];
+appController.$inject = ['$scope', '$rootScope', 'appListModel', 'deployService'];
 module.exports = appController;

--- a/app/js/deploy/appDirective.js
+++ b/app/js/deploy/appDirective.js
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2015 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * appDirective
+ * Defines a single application (in Lighthouse terms) as a component,
+ * which includes application specific information such as deploy history.
+ */
+function appDirective() {
+    'use strict';
+
+    return {
+        'controller': 'appController',
+        'restrict': 'A',
+        'scope': {
+            // application ID assigned at init
+            'info': '='
+        },
+        'template': require('./templates/app.html')
+    };
+}
+
+module.exports = appDirective;

--- a/app/js/deploy/appListController.js
+++ b/app/js/deploy/appListController.js
@@ -15,6 +15,7 @@
  */
 
 function appListController($scope, appListModel, deployService) {
+    'use strict';
 
     // Fetch application list
     deployService.apps();

--- a/app/js/deploy/appListController.js
+++ b/app/js/deploy/appListController.js
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2015 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+function appListController($scope, appListModel, deployService) {
+
+    // Fetch application list
+    deployService.apps();
+
+    $scope.$listenTo(appListModel, function () {
+        $scope.apps = appListModel.apps();
+        $scope.detail = appListModel.detail();
+    });
+
+}
+
+appListController.$inject = ['$scope', 'appListModel', 'deployService'];
+module.exports = appListController;

--- a/app/js/deploy/appListModel.js
+++ b/app/js/deploy/appListModel.js
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2015 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+var _ = require('lodash');
+
+function appListModel() {
+    'use strict';
+
+    function init() {
+        return {
+            'apps': [],
+            'detail': {}
+        };
+    }
+
+    return {
+        // State
+        state: init(),
+        handlers: {
+            'appDetail': 'detail',
+            'appList': 'list'
+        },
+
+        detail: function (r) {
+            this.state.detail[r.id.toString()] = _.sortBy(r.data, 'Id');
+            this.emitChange();
+        },
+
+        list: function (r) {
+            this.state.apps = r.data;
+            this.emitChange();
+        },
+
+        exports: {
+            apps: function () {
+                return this.state.apps;
+            },
+
+            detail: function (id) {
+                if (id === undefined) {
+                    return this.state.detail;
+                }
+
+                var ret = this.state.detail[id.toString()];
+                return ret ? ret : {};
+            }
+        }
+    };
+
+}
+
+module.exports = appListModel;

--- a/app/js/deploy/deployController.js
+++ b/app/js/deploy/deployController.js
@@ -79,10 +79,8 @@ function deployController($scope, beaconModel, deployService, dockerTemplate) {
     // Finalize the application deploy request object
     // and attempt the deployment.
     $scope.deploy = function () {
-        var targets = _.map($scope.instances, function (instance) {
-            if (instance.selected)
-                return instance.InstanceAddress;
-        });
+        var targets = _.map(_.where($scope.instances, {'selected': true}),
+            function (instance) { return instance.InstanceAddress; });
 
         // Format container command for Docker consumption
         // (as an array of strings)

--- a/app/js/deploy/deployController.js
+++ b/app/js/deploy/deployController.js
@@ -23,7 +23,9 @@ function deployController($scope, beaconModel, deployService, dockerTemplate) {
         var _instances = [];
         _.forEach(beaconModel.getBeacons(), function (beacon) {
             _.forEach(beaconModel.getInstances(beacon), function (instance) {
-                _instances.push(_.assign(instance, {'selected': false}));
+                if (instance.CanAccessDocker) {
+                    _instances.push(_.assign(instance, {'selected': false}));
+                }
             });
         });
 

--- a/app/js/deploy/deployService.js
+++ b/app/js/deploy/deployService.js
@@ -125,6 +125,25 @@ function deployService($http, actions, flux, configService) {
         _stream('POST', name, 'stop', url);
     }
 
+    /*
+     * update()
+     * Endpoint: /applications/update/{id}
+     * Dispatches: deployStream- prefixed actions
+     *
+     * @param {number, required} id - id of app to update
+     * @param {string, required} name - app name
+     * @param {object, required} body - update info (see API)
+     * @param {object, optional} query - query parameters object
+     */
+    function update(id, name, body, query) {
+        var url = [configService.api.base, 'applications/update/', id].join('');
+        if (query) {
+            url += ('?' + $.param(query));
+        }
+
+        _stream('PUT', name, 'update', url, body);
+    }
+
     /* 
      * apps()
      * Endpoint: /applications/list
@@ -173,7 +192,8 @@ function deployService($http, actions, flux, configService) {
         'create': create,
         'revert': revert,
         'start': start,
-        'stop': stop
+        'stop': stop,
+        'update': update
     };
 }
 

--- a/app/js/deploy/deployService.js
+++ b/app/js/deploy/deployService.js
@@ -42,9 +42,9 @@ function deployService($http, actions, flux, configService) {
         };
     }
 
-    function _stream(name, action, url, body) {
+    function _stream(method, name, action, url, body) {
         oboe({
-            'method': 'POST',
+            'method': method,
             'url': url,
             'body': body || {}
         })
@@ -78,7 +78,25 @@ function deployService($http, actions, flux, configService) {
             url += ('?' + $.param(request.query));
         }
 
-        _stream(request.body.Name, 'create', url, request.body);
+        _stream('POST', request.body.Name, 'create', url, request.body);
+    }
+
+    /*
+     * revert()
+     * Endpoint: /applications/revert/{id}
+     * Dispatches: deployStream- prefixed actions
+     *
+     * @param {number, required} id - target deployment id
+     * @param {string, required} name - app name
+     * @param {object, optional} query - query parameters object
+     */
+    function revert(id, name, query) {
+        var url = [configService.api.base, 'applications/revert/', id].join('');
+        if (query) {
+            url += ('?' + $.param(query));
+        }
+
+        _stream('PUT', name, 'revert', url);
     }
 
     /*
@@ -91,7 +109,7 @@ function deployService($http, actions, flux, configService) {
      */
     function start(id, name) {
         var url = [configService.api.base, 'applications/start/', id].join('');
-        _stream(name, 'start', url);
+        _stream('POST', name, 'start', url);
     }
 
     /*
@@ -104,7 +122,7 @@ function deployService($http, actions, flux, configService) {
      */
     function stop(id, name) {
         var url = [configService.api.base, 'applications/stop/', id].join('');
-        _stream(name, 'stop', url);
+        _stream('POST', name, 'stop', url);
     }
 
     /* 
@@ -153,6 +171,7 @@ function deployService($http, actions, flux, configService) {
         'apps': apps,
         'detail': detail,
         'create': create,
+        'revert': revert,
         'start': start,
         'stop': stop
     };

--- a/app/js/deploy/init.js
+++ b/app/js/deploy/init.js
@@ -32,6 +32,9 @@ var deployController = require('./deployController'),
     deployRevertController = require('./revert/deployRevertController'),
     deployRevertDirective = require('./revert/deployRevertDirective'),
 
+    deployUpdateController = require('./update/deployUpdateController'),
+    deployUpdateDirective = require('./update/deployUpdateDirective'),
+
     deployModel = require('./deployModel'),
     deployService = require('./deployService');
 
@@ -42,11 +45,13 @@ deploy.controller('appListController', appListController);
 deploy.controller('deployController', deployController);
 deploy.controller('deployMonitorController', deployMonitorController);
 deploy.controller('deployRevertController', deployRevertController);
+deploy.controller('deployUpdateController', deployUpdateController);
 
 deploy.directive('app', appDirective);
 deploy.directive('deployer', deployDirective);
 deploy.directive('deployMonitor', deployMonitorDirective);
 deploy.directive('deployRevert', deployRevertDirective);
+deploy.directive('deployUpdate', deployUpdateDirective);
 
 deploy.factory('deployError', deployError);
 deploy.factory('deployService', deployService);

--- a/app/js/deploy/init.js
+++ b/app/js/deploy/init.js
@@ -17,6 +17,7 @@
 // Application management
 var appController = require('./appController'),
     appDirective = require('./appDirective'),
+
     appListController = require('./appListController'),
     appListModel = require('./appListModel');
 
@@ -24,8 +25,13 @@ var appController = require('./appController'),
 var deployController = require('./deployController'),
     deployDirective = require('./deployDirective'),
     deployError = require('./deployError'),
+
     deployMonitorController = require('./monitor/deployMonitorController'),
     deployMonitorDirective = require('./monitor/deployMonitorDirective'),
+
+    deployRevertController = require('./revert/deployRevertController'),
+    deployRevertDirective = require('./revert/deployRevertDirective'),
+
     deployModel = require('./deployModel'),
     deployService = require('./deployService');
 
@@ -35,10 +41,12 @@ deploy.controller('appController', appController);
 deploy.controller('appListController', appListController);
 deploy.controller('deployController', deployController);
 deploy.controller('deployMonitorController', deployMonitorController);
+deploy.controller('deployRevertController', deployRevertController);
 
 deploy.directive('app', appDirective);
 deploy.directive('deployer', deployDirective);
 deploy.directive('deployMonitor', deployMonitorDirective);
+deploy.directive('deployRevert', deployRevertDirective);
 
 deploy.factory('deployError', deployError);
 deploy.factory('deployService', deployService);

--- a/app/js/deploy/init.js
+++ b/app/js/deploy/init.js
@@ -14,6 +14,13 @@
  *  limitations under the License.
  */
 
+// Application management
+var appController = require('./appController'),
+    appDirective = require('./appDirective'),
+    appListController = require('./appListController'),
+    appListModel = require('./appListModel');
+
+// Deployment control
 var deployController = require('./deployController'),
     deployDirective = require('./deployDirective'),
     deployError = require('./deployError'),
@@ -24,14 +31,19 @@ var deployController = require('./deployController'),
 
 var deploy = angular.module('lighthouse.deploy', []);
 
+deploy.controller('appController', appController);
+deploy.controller('appListController', appListController);
 deploy.controller('deployController', deployController);
 deploy.controller('deployMonitorController', deployMonitorController);
 
+deploy.directive('app', appDirective);
 deploy.directive('deployer', deployDirective);
 deploy.directive('deployMonitor', deployMonitorDirective);
 
 deploy.factory('deployError', deployError);
 deploy.factory('deployService', deployService);
+
+deploy.store('appListModel', appListModel);
 deploy.store('deployModel', deployModel);
 
 module.exports = deploy;

--- a/app/js/deploy/monitor/deployMonitorController.js
+++ b/app/js/deploy/monitor/deployMonitorController.js
@@ -23,6 +23,11 @@ var actionMessages = {
         'finished': 'Deployed {}!',
         'failed': 'Deploy for {} failed.'
     },
+    'revert': {
+        'started': 'Reverting {} ...',
+        'finished': 'Reverted {}!',
+        'failed': 'Could not revert {}.'
+    },
     'start': {
         'started': 'Starting {} ...',
         'finished': 'Started {}!',

--- a/app/js/deploy/monitor/deployMonitorController.js
+++ b/app/js/deploy/monitor/deployMonitorController.js
@@ -37,6 +37,11 @@ var actionMessages = {
         'started': 'Stopping {} ...',
         'finished': 'Stopped {}!',
         'failed': 'Could not stop {}.'
+    },
+    'update': {
+        'started': 'Updating {} ...',
+        'finished': 'Updated {}!',
+        'failed': 'Could not update {}.'
     }
 };
 

--- a/app/js/deploy/monitor/deployMonitorController.js
+++ b/app/js/deploy/monitor/deployMonitorController.js
@@ -16,6 +16,31 @@
 
 var _ = require('lodash');
 
+// TODO refactor to constant in deploy module
+var actionMessages = {
+    'create': {
+        'started': 'Deploying {} ...',
+        'finished': 'Deployed {}!',
+        'failed': 'Deploy for {} failed.'
+    },
+    'start': {
+        'started': 'Starting {} ...',
+        'finished': 'Started {}!',
+        'failed': 'Could not start {}.'
+    },
+    'stop': {
+        'started': 'Stopping {} ...',
+        'finished': 'Stopped {}!',
+        'failed': 'Could not stop {}.'
+    }
+};
+
+function _format(message, name) {
+    if (message.indexOf('{}') > -1) {
+        return message.replace('{}', name);
+    }
+}
+
 function deployMonitorController($scope, $timeout, actions, flux, deployError, deployModel) {
     'use strict';
 
@@ -26,12 +51,25 @@ function deployMonitorController($scope, $timeout, actions, flux, deployError, d
     $scope.request = deployModel.request();
     $scope.errors = [];
 
+    // UI
+    $scope.action = {};
+
     // state updates
     $scope.$listenTo(deployModel, function () {
         $scope.state = deployModel.state();
         $scope.inProgress = deployModel.inProgress();
         $scope.completed = deployModel.completed();
         $scope.request = deployModel.request();
+
+        var template = actionMessages[$scope.request.action];
+
+        if (template) {
+            _.assign($scope.action, {
+                'started': _format(template.started, $scope.request.appName),
+                'finished': _format(template.finished, $scope.request.appName),
+                'failed': _format(template.failed, $scope.request.appName),
+            });
+        }
 
         if ($scope.state.started && !$scope.state.good) {
             $scope.errors.push(deployError.display($scope.state.errorMessage));

--- a/app/js/deploy/revert/deployRevertController.js
+++ b/app/js/deploy/revert/deployRevertController.js
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2015 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+function deployRevertController($scope, deployService) {
+    'use strict';
+
+    $scope.query = {
+        'target': -1,
+        'forcePull': false
+    };
+
+    $scope.$on('deploy.revert', function (event, info) {
+        $scope.query.target = info.target;
+        $scope.id = info.id;
+        $scope.name = info.name;
+    });
+
+    $scope.confirm = function () {
+        deployService.revert($scope.id, $scope.name, $scope.query);
+    };
+}
+
+deployRevertController.$inject = ['$scope', 'deployService'];
+module.exports = deployRevertController;

--- a/app/js/deploy/revert/deployRevertDirective.js
+++ b/app/js/deploy/revert/deployRevertDirective.js
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2015 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * deployRevertDirective
+ * UI component to confirm a deployment revert.
+ */
+function deployRevertDirective() {
+    'use strict';
+
+    return {
+        'controller': 'deployRevertController',
+        'restrict': 'A',
+        'scope': {},
+        'template': require('../templates/deploy_revert.html')
+    };
+}
+
+module.exports = deployRevertDirective;

--- a/app/js/deploy/templates/app.html
+++ b/app/js/deploy/templates/app.html
@@ -12,7 +12,7 @@
         </div>
       </div>
       <div class="col-md-9">
-        <h5>{{recent.Creator}} deployed revision {{recent.Id}}</h5>
+        <h5>{{recent.Creator}} deployed with ID {{recent.Id}}</h5>
         <h6>{{recent.Date | fromISO:true}}</h6>
         <h6>Running {{recent.Image}}</h6>
       </div>

--- a/app/js/deploy/templates/app.html
+++ b/app/js/deploy/templates/app.html
@@ -3,11 +3,11 @@
     <div class="row">
       <div class="col-md-3">
         <h4>{{info.Name}} (ID: {{info.Id}})</h4>
-        <h6>Currently at revision {{info.CurrentDeployment}}</h6>
+        <h6>Deployment ID: {{info.CurrentDeployment}}</h6>
         <!-- control buttons -->
         <div class="btn-group" role="group" style="margin-right: 15px;">
-          <button type="button" class="btn btn-default btn-sm"><i class="fa fa-play"></i> Start</button>
-          <button type="button" class="btn btn-default btn-sm"><i class="fa fa-stop"></i> Stop</button>
+          <button ng-click="start(info.Id)" type="button" class="btn btn-default btn-sm"><i class="fa fa-play"></i> Start</button>
+          <button ng-click="stop(info.Id)" type="button" class="btn btn-default btn-sm"><i class="fa fa-stop"></i> Stop</button>
           <button type="button" class="btn btn-default btn-sm"><i class="fa fa-repeat"></i> Revert</button>
         </div>
       </div>

--- a/app/js/deploy/templates/app.html
+++ b/app/js/deploy/templates/app.html
@@ -15,7 +15,16 @@
         <h5>{{recent.Creator}} deployed with ID {{recent.Id}}</h5>
         <h6>{{recent.Date | fromISO:true}}</h6>
         <h6>Running {{recent.Image}}</h6>
+        <a ng-show="!showHistory" ng-click="showHistory = !showHistory" href="#">Show recent deployments</a>
+        <a ng-show="showHistory" ng-click="showHistory = !showHistory" href="#">Hide recent deployments</a>
       </div>
     </div>
   </div>
+</div>
+<div ng-show="showHistory">
+  <ul class="list-group">
+    <li class="list-group-item" ng-repeat="deploy in detail">
+      {{deploy.Creator}} deployed using <code>{{deploy.Image}}</code> {{deploy.Date | fromISO:true}} with ID {{deploy.Id}}
+    </li>
+  </ul>
 </div>

--- a/app/js/deploy/templates/app.html
+++ b/app/js/deploy/templates/app.html
@@ -1,5 +1,21 @@
 <div class="well">
-  <h5>{{info.Name}} (ID: {{info.Id}})</h5>
-  <h6>Currently at revision {{info.CurrentDeployment}}</h6>
-  <h6>{{recent.Creator}}</h6>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-3">
+        <h4>{{info.Name}} (ID: {{info.Id}})</h4>
+        <h6>Currently at revision {{info.CurrentDeployment}}</h6>
+        <!-- control buttons -->
+        <div class="btn-group" role="group" style="margin-right: 15px;">
+          <button type="button" class="btn btn-default btn-sm"><i class="fa fa-play"></i> Start</button>
+          <button type="button" class="btn btn-default btn-sm"><i class="fa fa-stop"></i> Stop</button>
+          <button type="button" class="btn btn-default btn-sm"><i class="fa fa-repeat"></i> Revert</button>
+        </div>
+      </div>
+      <div class="col-md-9">
+        <h5>{{recent.Creator}} deployed revision {{recent.Id}}</h5>
+        <h6>{{recent.Date | fromISO:true}}</h6>
+        <h6>Running {{recent.Image}}</h6>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/js/deploy/templates/app.html
+++ b/app/js/deploy/templates/app.html
@@ -1,0 +1,5 @@
+<div class="well">
+  <h5>{{info.Name}} (ID: {{info.Id}})</h5>
+  <h6>Currently at revision {{info.CurrentDeployment}}</h6>
+  <h6>{{recent.Creator}}</h6>
+</div>

--- a/app/js/deploy/templates/app.html
+++ b/app/js/deploy/templates/app.html
@@ -6,9 +6,14 @@
         <h6>Deployment ID: {{info.CurrentDeployment}}</h6>
         <!-- control buttons -->
         <div class="btn-group" role="group" style="margin-right: 15px;">
-          <button ng-click="start(info.Id)" type="button" class="btn btn-default btn-sm"><i class="fa fa-play"></i> Start</button>
-          <button ng-click="stop(info.Id)" type="button" class="btn btn-default btn-sm"><i class="fa fa-stop"></i> Stop</button>
-          <button type="button" class="btn btn-default btn-sm"><i class="fa fa-repeat"></i> Revert</button>
+          <button ng-click="start(info.Id)" type="button" class="btn btn-default btn-sm">
+            <i class="fa fa-play"></i> Start</button>
+          <button ng-click="stop(info.Id)" type="button" class="btn btn-default btn-sm">
+            <i class="fa fa-stop"></i> Stop</button>
+          <button ng-click="revert(-1)" type="button" class="btn btn-default btn-sm"
+                  data-toggle="modal" data-target="#deploy-revert-modal"
+                  title="Rollback one deployment.">
+            <i class="fa fa-repeat"></i> Revert</button>
         </div>
       </div>
       <div class="col-md-9">
@@ -24,6 +29,9 @@
 <div ng-show="showHistory">
   <ul class="list-group">
     <li class="list-group-item" ng-repeat="deploy in detail">
+      <button ng-click="revert(deploy.Id)" type="button" class="btn btn-default btn-sm"
+              data-toggle="modal" data-target="#deploy-revert-modal"
+              title="Rollback to this deployment."><i class="fa fa-repeat"></i></button>&nbsp;
       {{deploy.Creator}} deployed using <code>{{deploy.Image}}</code> {{deploy.Date | fromISO:true}} with ID {{deploy.Id}}
     </li>
   </ul>

--- a/app/js/deploy/templates/app.html
+++ b/app/js/deploy/templates/app.html
@@ -15,6 +15,11 @@
                   title="Rollback one deployment.">
             <i class="fa fa-repeat"></i> Revert</button>
         </div>
+        <div class="btn-group" role="group" style="margin-top: 10px;">
+          <button ng-click="update()" type="button" class="btn btn-default btn-sm"
+                  data-toggle="modal" data-target="#deploy-update-modal">
+            <i class="fa fa-edit"></i> Update</button>
+        </div>
       </div>
       <div class="col-md-9">
         <h5>{{recent.Creator}} deployed with ID {{recent.Id}}</h5>

--- a/app/js/deploy/templates/app_list.html
+++ b/app/js/deploy/templates/app_list.html
@@ -1,7 +1,14 @@
 <div class="container">
   <div class="row">
-    <div class="col-md-12">
+    <div class="col-md-12" ng-show="apps.length">
       <h4>Currently deployed applications</h4>
+    </div>
+    <!-- no app deployed -->
+    <div class="col-md-12" ng-show="!apps.length">
+      <h4>You have no currently deployed applications... </h4>
+      <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#deployer-modal">
+        <i class="fa fa-play"></i> Deploy App
+      </button>
     </div>
   </div>
   <div class="row">
@@ -13,3 +20,5 @@
     </div>
   </div>
 </div>
+
+<div deployer></div>

--- a/app/js/deploy/templates/app_list.html
+++ b/app/js/deploy/templates/app_list.html
@@ -27,3 +27,4 @@
 </div>
 
 <div deployer></div>
+<div deploy-revert></div>

--- a/app/js/deploy/templates/app_list.html
+++ b/app/js/deploy/templates/app_list.html
@@ -1,5 +1,10 @@
 <div class="container">
   <div class="row">
+    <div class="col-md-12">
+      <div deploy-monitor></div>
+    </div>
+  </div>
+  <div class="row">
     <div class="col-md-12" ng-show="apps.length">
       <h4>Currently deployed applications</h4>
     </div>

--- a/app/js/deploy/templates/app_list.html
+++ b/app/js/deploy/templates/app_list.html
@@ -28,3 +28,4 @@
 
 <div deployer></div>
 <div deploy-revert></div>
+<div deploy-update></div>

--- a/app/js/deploy/templates/app_list.html
+++ b/app/js/deploy/templates/app_list.html
@@ -1,0 +1,15 @@
+<div class="container">
+  <div class="row">
+    <div class="col-md-12">
+      <h4>Currently deployed applications</h4>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12">
+      <!-- application list -->
+      <div ng-repeat="app in apps track by $index">
+        <div app info="app"></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/js/deploy/templates/deploy_monitor.html
+++ b/app/js/deploy/templates/deploy_monitor.html
@@ -1,7 +1,7 @@
 <div class="well" ng-show="state.started">
-    <h4 ng-show="!state.finished"><i class="fa fa-refresh fa-spin"></i> Deploying {{request.Name}} ...</h4>
-    <h4 ng-show="state.finished && state.good"><i class="fa fa-check"></i> Deployed {{request.Name}}!</h4>
-    <h4 ng-show="state.finished && !state.good"><i class="fa fa-exclamation-circle"></i> Deploy for {{request.Name}} failed.</h4>
+    <h4 ng-show="!state.finished"><i class="fa fa-refresh fa-spin"></i> {{action.started}}</h4>
+    <h4 ng-show="state.finished && state.good"><i class="fa fa-check"></i> {{action.finished}}</h4>
+    <h4 ng-show="state.finished && !state.good"><i class="fa fa-exclamation-circle"></i> {{action.failed}}</h4>
 
     <div ng-repeat="error in errors" class="alert alert-danger">
         {{ error }}

--- a/app/js/deploy/templates/deploy_revert.html
+++ b/app/js/deploy/templates/deploy_revert.html
@@ -1,0 +1,28 @@
+<div class="modal fade"
+     id="deploy-revert-modal"
+     tabindex="-1"
+     role="dialog">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button"
+                        class="close"
+                        data-dismiss="modal">
+                    <span>&times;</span>
+                </button>
+                <h4>Are you sure you want to revert?</h4>
+            </div>
+            <div class="modal-body">
+                <form>
+                    <div class="form-group">
+                        Target ID: {{query.target}}
+                        <div class="checkbox">
+                            <label><input type="checkbox" ng-model="query.forcePull"> Force pull non-existent images</label>
+                        </div>
+                    </div>
+                    <button class="btn btn-success" data-dismiss="modal" ng-click="confirm()" type="submit">Do it!</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/js/deploy/templates/deploy_update.html
+++ b/app/js/deploy/templates/deploy_update.html
@@ -1,0 +1,45 @@
+<div class="modal fade"
+     id="deploy-update-modal"
+     tabindex="-1"
+     role="dialog">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button"
+                        class="close"
+                        data-dismiss="modal">
+                    <span>&times;</span>
+                </button>
+                <h4>Update application</h4>
+            </div>
+            <div class="modal-body">
+                <form>
+                    <div class="checkbox">
+                        <label><input type="checkbox" ng-model="query.restart">&nbsp;Restart containers</label>
+                    </div>
+
+                    <h5>Update Instances</h5>
+                    <div class="list-group">
+                        <a href="#" class="list-group-item"
+                           ng-repeat="instance in instances"
+                           ng-class="{'list-group-item-success': instance.selected}"
+                           ng-click="updateInclude(instance)">
+                           <i class="fa fa-check" ng-show="instance.selected"></i>&nbsp;{{instance.Alias}}</a>
+                    </div>
+
+                    <h5>... with create command:</h5>
+                    <div ng-show="jsonError" class="alert alert-danger">
+                        Unable to parse given JSON object.
+                    </div>
+                    <textarea id="dockerRequest" class="form-control" rows="15" ng-model="createCommand"
+                              ng-blur="updateCommand()" style="font-family: monospace; font-size: 14px;"></textarea>
+
+                    <button class="btn btn-success"
+                            data-dismiss="modal"
+                            ng-click="updateApp()"
+                            type="submit">Update</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/js/deploy/templates/deployer.html
+++ b/app/js/deploy/templates/deployer.html
@@ -21,11 +21,13 @@
                     </div>
                     <div class="form-group">
                         <label>Image</label>
-                        <input type="text" class="form-control" placeholder="image:tag" ng-model="request.Command.Image">
+                        <input type="text" class="form-control" placeholder="image:tag"
+                               ng-model="request.Command.Image" ng-change="updateCommand()">
                     </div>
                     <div class="form-group">
                         <label>Command</label>
-                        <input type="text" class="form-control" placeholder="/bin/bash" ng-model="request.Command.Cmd">
+                        <input type="text" class="form-control" placeholder="/bin/bash"
+                               ng-model="request.Command.Cmd" ng-change="updateCommand()">
                     </div>
                     <div class="checkbox">
                         <label><input type="checkbox" ng-model="query.forcePull"> Force pull non-existent images</label>
@@ -45,8 +47,8 @@
                     <h5 data-toggle="collapse" data-target="#dockerRequest">
                         <i class="fa fa-caret-down" ng-show="showRequest"></i>
                         <i class="fa fa-caret-right" ng-show="!showRequest"></i>&nbsp;Docker container create request</h5>
-                    <textarea id="dockerRequest" class="form-control collapse" rows="15"
-                              style="font-family: monospace; font-size: 14px;">{{request.Command | stringify}}</textarea>
+                    <textarea id="dockerRequest" class="form-control collapse" rows="15" ng-model="rawCommand"
+                              style="font-family: monospace; font-size: 14px;"></textarea>
 
                     <button class="btn btn-success"
                             data-dismiss="modal"

--- a/app/js/deploy/templates/deployer.html
+++ b/app/js/deploy/templates/deployer.html
@@ -17,17 +17,17 @@
                     <div class="form-group">
                         <label data-toggle="tooltip" data-placement="right"
                                title="Names help Lighthouse track apps across multiple Docker instances.">Name</label>
-                        <input type="text" class="form-control" placeholder="application-name" ng-model="request.Name">
+                        <input type="text" class="form-control" placeholder="application-name" ng-model="appName">
                     </div>
                     <div class="form-group">
                         <label>Image</label>
                         <input type="text" class="form-control" placeholder="image:tag"
-                               ng-model="request.Command.Image" ng-change="updateCommand()">
+                               ng-model="appImage" ng-change="updateCommand()">
                     </div>
                     <div class="form-group">
                         <label>Command</label>
                         <input type="text" class="form-control" placeholder="/bin/bash"
-                               ng-model="request.Command.Cmd" ng-change="updateCommand()">
+                               ng-model="appCmd" ng-change="updateCommand()">
                     </div>
                     <div class="checkbox">
                         <label><input type="checkbox" ng-model="query.forcePull"> Force pull non-existent images</label>
@@ -44,11 +44,14 @@
                            <i class="fa fa-check" ng-show="instance.selected"></i>&nbsp;{{instance.Alias}}</a>
                     </div>
 
+                    <div ng-show="jsonError" class="alert alert-danger">
+                        Unable to parse given JSON object.
+                    </div>
                     <h5 data-toggle="collapse" data-target="#dockerRequest">
                         <i class="fa fa-caret-down" ng-show="showRequest"></i>
                         <i class="fa fa-caret-right" ng-show="!showRequest"></i>&nbsp;Docker container create request</h5>
                     <textarea id="dockerRequest" class="form-control collapse" rows="15" ng-model="rawCommand"
-                              style="font-family: monospace; font-size: 14px;"></textarea>
+                              ng-blur="updateCommand()" style="font-family: monospace; font-size: 14px;"></textarea>
 
                     <button class="btn btn-success"
                             data-dismiss="modal"

--- a/app/js/deploy/update/deployUpdateController.js
+++ b/app/js/deploy/update/deployUpdateController.js
@@ -39,11 +39,13 @@ function deployUpdateController($scope, beaconModel, beaconService, deployServic
 
         _.forEach(beaconModel.getBeacons(), function (beacon) {
             _.forEach(beaconModel.getInstances(beacon), function (instance) {
-                if (_.includes(deployInstances, instance.InstanceAddress)) {
-                    _instances.push(_.assign(instance, {'selected': true}));
-                }
-                else {
-                    _instances.push(_.assign(instance, {'selected': false}));
+                if (instance.CanAccessDocker) {
+                    if (_.includes(deployInstances, instance.InstanceAddress)) {
+                        _instances.push(_.assign(instance, {'selected': true}));
+                    }
+                    else {
+                        _instances.push(_.assign(instance, {'selected': false}));
+                    }
                 }
             });
         });

--- a/app/js/deploy/update/deployUpdateController.js
+++ b/app/js/deploy/update/deployUpdateController.js
@@ -131,6 +131,9 @@ function deployUpdateController($scope, beaconModel, beaconService, deployServic
                 deployService.apps();
                 deployService.detail($scope.id);
             });
+
+        toRemove = [];
+        toAdd = [];
     };
 }
 

--- a/app/js/deploy/update/deployUpdateController.js
+++ b/app/js/deploy/update/deployUpdateController.js
@@ -1,0 +1,133 @@
+/*
+ *  Copyright 2015 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+var _ = require('lodash');
+
+function deployUpdateController($scope, beaconModel, beaconService, deployService) {
+    'use strict';
+
+    // TODO attempt to fix issue with beaconModel not populated on refresh.
+    // proper solution would be to define some kind of data dependency between models
+    // and controllers.
+    // 
+    // // Load data deps
+    // if (_.isEmpty(beaconModel.getBeacons())) {
+    //     console.log('loading beacons!');
+    //     beaconService.getBeacons();
+    //     console.log(beaconModel.getBeacons());
+    //     _.forEach(beaconModel.getBeacons(), function (beacon) {
+    //         console.log('fetching instances for beacon');
+    //         beaconService.getInstances(beacon);
+    //     });
+    // }
+
+    function _buildInstanceList(deployInstances) {
+        var _instances = [];
+
+        _.forEach(beaconModel.getBeacons(), function (beacon) {
+            _.forEach(beaconModel.getInstances(beacon), function (instance) {
+                if (_.includes(deployInstances, instance.InstanceAddress)) {
+                    _instances.push(_.assign(instance, {'selected': true}));
+                }
+                else {
+                    _instances.push(_.assign(instance, {'selected': false}));
+                }
+            });
+        });
+
+        $scope.instances = _instances;
+        currentInstances = _.where(_instances, {'selected': true});
+    }
+
+    // Recent deploy object
+    $scope.recent = {};
+    $scope.id = 0;
+    $scope.createCommand = '';
+    $scope.query = {
+        'restart': false
+    };
+    // Instance selection
+    $scope.instances = [];
+    // UI state
+    $scope.jsonError = false;
+
+    // Instance mgmt
+    var currentInstances = [];
+    var toAdd = [];
+    var toRemove = [];
+
+    // Init
+    $scope.$on('deploy.update', function (event, info) {
+        $scope.id = info.id;
+        $scope.name = info.name;
+        $scope.recent = info.recent;
+        // four spaces
+        $scope.createCommand = JSON.stringify($scope.recent.Command, null, '    ');
+        _buildInstanceList(info.recent.Instances);
+    });
+
+    $scope.updateCommand = function () {
+        try {
+            JSON.parse($scope.createCommand, null, '    ');
+            $scope.jsonError = false;
+        } catch (e) {
+            $scope.jsonError = true;
+        }
+    };
+
+    $scope.updateInclude = function (instance) {
+        if (_.includes(currentInstances, instance)) {
+            if (instance.selected) {
+                toRemove.push(instance);
+            }
+            else {
+                toRemove = _.without(toRemove, instance);
+            }
+        }
+        else {
+            if (instance.selected) {
+                toAdd = _.without(toAdd, instance);
+            }
+            else {
+                toAdd.push(instance);
+            }
+        }
+
+        instance.selected = !instance.selected;
+    };
+
+    $scope.updateApp = function () {
+        var command = {};
+        try {
+            command = JSON.parse($scope.createCommand);
+            $scope.jsonError = false;
+        } catch (e) {
+            $scope.jsonError = true;
+            return;
+        }
+
+        var update = {
+            'Command': command,
+            'Add': _.map(toAdd, function (inst) { return inst.InstanceAddress; }),
+            'Remove': _.map(toRemove, function (inst) { return inst.InstanceAddress; })
+        };
+
+        deployService.update($scope.id, $scope.name, update, $scope.query);
+    };
+}
+
+deployUpdateController.$inject = ['$scope', 'beaconModel', 'beaconService', 'deployService'];
+module.exports = deployUpdateController;

--- a/app/js/deploy/update/deployUpdateDirective.js
+++ b/app/js/deploy/update/deployUpdateDirective.js
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2015 Caleb Brose, Chris Fogerty, Rob Sheehy, Zach Taylor, Nick Miller
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * deployUpdateDirective
+ * UI component to update an application command and instances.
+ */
+function deployUpdateDirective() {
+    'use strict';
+
+    return {
+        'controller': 'deployUpdateController',
+        'restrict': 'A',
+        'scope': {},
+        'template': require('../templates/deploy_update.html')
+    };
+}
+
+module.exports = deployUpdateDirective;

--- a/app/js/docker/dockerTemplate.js
+++ b/app/js/docker/dockerTemplate.js
@@ -23,6 +23,8 @@ module.exports = {
         'Cmd': [],
         'Entrypoint': '',
         'Image': '',
-        'ExposedPorts': {}
+        'ExposedPorts': {},
+        'OpenStdin': false,
+        'Tty': false
     }
 };

--- a/app/js/nav/templates/nav.html
+++ b/app/js/nav/templates/nav.html
@@ -9,9 +9,12 @@
     <div ng-if="loggedIn" class="collapse navbar-collapse">
       <ul class="nav navbar-nav">
         <li>
+          <a href="/apps">Applications</a>
+        </li>
+        <li>
           <a href="/beacons">Beacons</a>
         </li>
-        <li ng-if="user.AuthLevel>=1">
+        <li ng-if="user.AuthLevel >= 1">
           <a href="/users">Users</a>
         </li>
       </ul>

--- a/app/js/routes/routeConfig.js
+++ b/app/js/routes/routeConfig.js
@@ -26,6 +26,10 @@ function routeConfig($routeProvider) {
             controller: 'loginController'
         })
         // Functionality
+        .when('/apps', {
+            template: require('../deploy/templates/app_list.html'),
+            controller: 'appListController'
+        })
         .when('/beacons', {
             template: require('../beacons/templates/beacon_list.html'),
             controller: 'beaconListController'

--- a/app/js/transform/init.js
+++ b/app/js/transform/init.js
@@ -44,9 +44,24 @@ transform.filter('fromEpoch', function() {
         if (toRelative) {
             return moment.unix(epoch).fromNow();
         }
+        
         return moment.unix(epoch);
     };
+});
 
+/*
+ * fromISO (filter)
+ * @param {string} timestamp - ISO 8601 formatted timestamp
+ * @param {boolean} toRelative - if true, uses moment's .fromNow() to obtain a relative date
+ */
+transform.filter('fromISO', function () {
+    return function(timestamp, toRelative) {
+        if (toRelative) {
+            return moment(timestamp).fromNow();
+        }
+
+        return moment(timestamp);
+    };
 });
 
 /*

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "angular-route": "^1.3.3",
     "flux-angular": "^2.1.2",
     "keymirror": "^0.1.1",
-    "lodash": "^3.5.0",
+    "lodash": "^3.7.0",
     "moment": "^2.9.0",
     "object-assign": "^2.0.0",
     "oboe": "2.1.1"


### PR DESCRIPTION
### What

Feature completeness for the `/applications/` API. Generalized stream model and app component goodness!

### How

The critical addition is the `/apps` page, which displays each known app as a directive-controlled component. Each app component is responsible for pulling its own detailed state and history (see `appController`)

To support multiple streaming endpoints, I had to generalize the `deployModel#start` handler to initialize with the app name and "action" ("create", "start", "stop", etc) so the same `deploy-monitor` component could be replicated from the beacons page.

### Notes

* updated lodash to `3.7.0` **Be sure to run `npm install`**

- [x] `/applications/create` (handled in #41)
- [x] `/applications/start/{id}`
- [x] `/applications/stop/{id}`
- [x] `/applications/update/{id}`
- [x] `/applications/revert/{id}`
- [x] `/applications/list`
- [x] `/applications/list/{id}` (history)

![screen shot 2015-04-26 at 8 42 54 pm](https://cloud.githubusercontent.com/assets/965744/7340523/f5fbbab8-ec54-11e4-99cd-bd0efe03f17a.png)

